### PR TITLE
Added missing service dependencies for SLAM node

### DIFF
--- a/realsense_ros_slam/CMakeLists.txt
+++ b/realsense_ros_slam/CMakeLists.txt
@@ -76,6 +76,9 @@ target_link_libraries(${PROJECT_NAME}
   ${LIBRARIES_TO_LINK}
 )
 
+add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_generate_messages_cpp)
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+
 if (REALSENSE_ENABLE_TESTING)
   find_package(rostest REQUIRED)
 


### PR DESCRIPTION
The SLAM node is missing dependencies that may prevent the services from being created before the node was compiled, causing a compiler error.