### PR TITLE
Add dependencies in ros_slam CMakeLists.

### DIFF
--- a/realsense_ros_slam/CMakeLists.txt
+++ b/realsense_ros_slam/CMakeLists.txt
@@ -63,6 +63,8 @@ file(GLOB SOURCES
 
 add_library(${PROJECT_NAME} ${SOURCES})
 
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS})
+
 set(LIBRARIES_TO_LINK
     realsense
     realsense_image


### PR DESCRIPTION
Without this compilation failed for me with `catkin build`, since the library is compiled before the messages are generated.

Error message without this PR:

```
demmeln@atcremers67:~/work/ros_ws/src/realsense_samples_ros$ catkin build realsense_ros_slam -j1
------------------------------------------------------------------
Profile:                     default
Extending:        [explicit] /opt/ros/kinetic
Workspace:                   /usr/wiss/demmeln/work/ros_ws
------------------------------------------------------------------
Source Space:       [exists] /usr/wiss/demmeln/work/ros_ws/src
Log Space:          [exists] /usr/wiss/demmeln/work/ros_ws/logs
Build Space:        [exists] /usr/wiss/demmeln/work/ros_ws/build
Devel Space:        [exists] /usr/wiss/demmeln/work/ros_ws/devel
Install Space:      [unused] /usr/wiss/demmeln/work/ros_ws/install
DESTDIR:            [unused] None
------------------------------------------------------------------
Devel Space Layout:          linked
Install Space Layout:        None
------------------------------------------------------------------
Additional CMake Args:       -DCMAKE_BUILD_TYPE=Release
Additional Make Args:        -j1
Additional catkin Make Args: None
Internal Make Job Server:    True
Cache Job Environments:      False
------------------------------------------------------------------
Whitelisted Packages:        None
Blacklisted Packages:        
------------------------------------------------------------------
Workspace configuration appears valid.

NOTE: Forcing CMake to run for each package.
------------------------------------------------------------------
[build] Found '7' packages in 0.0 seconds.                                                                                                                                                                                              
[build] Package table is up to date.                                                                                                                                                                                                    
Starting  >>> realsense_ros_camera                                                                                                                                                                                                      
Finished  <<< realsense_ros_camera                [ 2.6 seconds ]                                                                                                                                                                       
Starting  >>> realsense_ros_slam                                                                                                                                                                                                        
________________________________________________________________________________________________________________________________________________________________________________________________________________________________________
Errors     << realsense_ros_slam:make /usr/wiss/demmeln/work/ros_ws/logs/realsense_ros_slam/build.make.005.log                                                                                                                          
In file included from /usr/wiss/demmeln/work/ros_ws/src/realsense_samples_ros/realsense_ros_slam/src/slam_nodelet.cpp:4:0:
/usr/wiss/demmeln/work/ros_ws/src/realsense_samples_ros/realsense_ros_slam/include/realsense_ros_slam/slam_nodelet.h:39:38: fatal error: realsense_ros_slam/Reset.h: No such file or directory
compilation terminated.
make[2]: *** [CMakeFiles/realsense_ros_slam.dir/src/slam_nodelet.cpp.o] Error 1
make[1]: *** [CMakeFiles/realsense_ros_slam.dir/all] Error 2
make: *** [all] Error 2
cd /usr/wiss/demmeln/work/ros_ws/build/realsense_ros_slam; catkin build --get-env realsense_ros_slam | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
........................................................................................................................................................................................................................................
Failed     << realsense_ros_slam:make             [ Exited with code 2 ]                                                                                                                                                                
Failed    <<< realsense_ros_slam                  [ 3.4 seconds ]                                                                                                                                                                       
[build] Summary: 1 of 2 packages succeeded.                                                                                                                                                                                             
[build]   Ignored:   5 packages were skipped or are blacklisted.                                                                                                                                                                        
[build]   Warnings:  None.                                                                                                                                                                                                              
[build]   Abandoned: None.                                                                                                                                                                                                              
[build]   Failed:    1 packages failed.                                                                                                                                                                                                 
[build] Runtime: 6.0 seconds total.                                                                                                                                                                                                     
[build] Note: Workspace packages have changed, please re-source setup files to use them.
```



